### PR TITLE
Editor / Automatically populate resource dct:type

### DIFF
--- a/src/main/plugin/dcat2/layout/config-editor.xml
+++ b/src/main/plugin/dcat2/layout/config-editor.xml
@@ -127,6 +127,13 @@
         max="1"
         labelKey="dcat.addAccessRight"/>
     </for>
+    <for name="dct:accessRights" xpath="dcat:Distribution" use="thesaurus-list-picker">
+      <directiveAttributes
+        thesaurus="external.theme.eu.europa.access-right"
+        xpath="//dcat:Distribution/dct:accessRights"
+        max="1"
+        labelKey="dcat.addAccessRight"/>
+    </for>
 
     <!--
     TODO: We can't use that. See layout-custom-fields-keywords.xsl to add a snippet skos:Concept

--- a/src/main/plugin/dcat2/layout/config-editor.xml
+++ b/src/main/plugin/dcat2/layout/config-editor.xml
@@ -64,20 +64,6 @@
         max=""
         labelKey="dcat.addThemes"/>
     </for>
-    <for name="dct:type" xpath="dcat:Dataset" use="thesaurus-list-picker">
-      <directiveAttributes
-        thesaurus="external.theme.dcat-type"
-        xpath="/dct:type"
-        max="1"
-        labelKey="dcat.addType"/>
-    </for>
-    <for name="dct:type" xpath="dcat:DataService" use="thesaurus-list-picker">
-      <directiveAttributes
-        thesaurus="external.theme.dcat-type"
-        xpath="/dct:type"
-        max="1"
-        labelKey="dcat.addType"/>
-    </for>
     <for name="dcat:keyword" use="thesaurus-list-picker">
       <directiveAttributes
         thesaurus="external.none.allThesaurus"
@@ -258,7 +244,6 @@
 
           <field xpath="rdf:RDF/*/dcat:theme" or="theme" in="rdf:RDF/*"/>
           <field xpath="rdf:RDF/*/dcat:keyword" or="keyword" in="rdf:RDF/*"/>
-          <field xpath="rdf:RDF/*/dct:type" or="type" in="rdf:RDF/*"/>
 
           <field xpath="rdf:RDF/(dcat:Dataset|dcat:DataService)/dct:issued" or="issued" in="rdf:RDF/*"/>
           <field xpath="rdf:RDF/(dcat:Dataset|dcat:DataService)/dct:modified" or="modified" in="rdf:RDF/*"/>

--- a/src/main/plugin/dcat2/layout/layout-custom-fields-keywords.xsl
+++ b/src/main/plugin/dcat2/layout/layout-custom-fields-keywords.xsl
@@ -70,22 +70,15 @@
   TODO: How to deal with value not in the thesaurus ?
   -->
   <xsl:template mode="mode-dcat2" priority="4000"
-                match="*[name() = $dcatKeywordConfig//@name]">
+                match="*[gn-fn-dcat2:getThesaurusConfig(name(), name(..))]">
     <xsl:variable name="name" select="name()"/>
-    <xsl:variable name="parent" select="name(..)"/>
-
-    <!-- Element with cardinality 0..1 once defined, does not have gn:child equivalent.
-    Render form here. -->
     <xsl:variable name="hasGnChild" select="count(../gn:child[concat(@prefix, ':', @name) = $name]) > 0"/>
 
     <xsl:if test="not($hasGnChild)">
       <xsl:variable name="isFirst"
                     select="count(preceding-sibling::*[name() = $name]) &lt; 1"/>
       <xsl:if test="$isFirst">
-        <xsl:variable name="config"
-                      select="if ($dcatKeywordConfig/*[@name = $name and @parent = $parent]) then
-                                $dcatKeywordConfig/*[@name = $name and @parent = $parent] else
-                                $dcatKeywordConfig/*[@name = $name and not(@parent)]"/>
+        <xsl:variable name="config" select="gn-fn-dcat2:getThesaurusConfig(name(), name(..))"/>
 
         <xsl:call-template name="thesaurus-picker-list">
           <xsl:with-param name="config" select="$config"/>
@@ -96,14 +89,8 @@
   </xsl:template>
 
   <xsl:template mode="mode-dcat2" priority="4000"
-                match="gn:child[concat(@prefix, ':', @name) = $dcatKeywordConfig//@name]">
-    <xsl:variable name="name" select="concat(@prefix, ':', @name)"/>
-    <xsl:variable name="parent" select="name(..)"/>
-    <xsl:variable name="config"
-                  select="if ($dcatKeywordConfig/*[@name = $name and @parent = $parent]) then
-                                $dcatKeywordConfig/*[@name = $name and @parent = $parent] else
-                                $dcatKeywordConfig/*[@name = $name and not(@parent)]"/>
-
+                match="gn:child[gn-fn-dcat2:getThesaurusConfig(concat(@prefix, ':', @name), name(..))]">
+    <xsl:variable name="config" select="gn-fn-dcat2:getThesaurusConfig(concat(@prefix, ':', @name), name(..))"/>
     <xsl:call-template name="thesaurus-picker-list">
       <xsl:with-param name="config" select="$config"/>
       <xsl:with-param name="ref" select="../gn:element/@ref"/>
@@ -158,4 +145,12 @@
     </div>
   </xsl:template>
 
+  <xsl:function name="gn-fn-dcat2:getThesaurusConfig">
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:param name="parent" as="xs:string"/>
+    <xsl:copy-of select="if ($dcatKeywordConfig/*[@name = $name and @parent = $parent]) then
+                                $dcatKeywordConfig/*[@name = $name and @parent = $parent] else
+                                $dcatKeywordConfig/*[@name = $name and not(@parent)]"/>
+
+  </xsl:function>
 </xsl:stylesheet>

--- a/src/main/plugin/dcat2/update-fixed-info.xsl
+++ b/src/main/plugin/dcat2/update-fixed-info.xsl
@@ -301,7 +301,14 @@
       <xsl:apply-templates select="dcat:theme"/>
       <xsl:apply-templates select="dcat:keyword"/>
 
-      <xsl:call-template name="add-resource-type"/>
+      <xsl:choose>
+        <xsl:when test="dct:type">
+          <xsl:apply-templates select="dct:type"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:call-template name="add-resource-type"/>
+        </xsl:otherwise>
+      </xsl:choose>
 
       <xsl:apply-templates select="dct:creator"/>
       <xsl:apply-templates select="dct:publisher"/>

--- a/src/main/plugin/dcat2/update-fixed-info.xsl
+++ b/src/main/plugin/dcat2/update-fixed-info.xsl
@@ -236,6 +236,32 @@
     <xsl:namespace name="gml" select="'http://www.opengis.net/gml/3.2'"/>
   </xsl:template>
 
+  <xsl:template name="add-resource-type">
+    <xsl:variable name="inScheme" select="'https://registry.geonetwork-opensource.org/dcat/type'"/>
+    <xsl:variable name="typeURI">
+      <xsl:choose>
+        <xsl:when test="name() = 'dcat:Dataset'">
+          <xsl:value-of select="concat($inScheme, '/', 'dataset')"/>
+        </xsl:when>
+        <xsl:when test="name() = 'dcat:DataService'">
+          <xsl:value-of select="concat($inScheme, '/', 'service')"/>
+        </xsl:when>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="thesaurusKey" select="'external.theme.dcat-type'"/>
+
+    <dct:type>
+      <skos:Concept rdf:about="{$typeURI}">
+        <xsl:for-each select="$locales/lang/@code">
+          <skos:prefLabel xml:lang="{.}">
+            <xsl:value-of select="java:getKeywordValueByUri($typeURI, $thesaurusKey, .)"/>
+          </skos:prefLabel>
+        </xsl:for-each>
+        <skos:inScheme rdf:resource="{$inScheme}"/>
+      </skos:Concept>
+    </dct:type>
+  </xsl:template>
+
   <xsl:template match="rdf:RDF" priority="10">
     <xsl:copy>
       <xsl:call-template name="add-namespaces"/>
@@ -274,7 +300,8 @@
 <!--      <xsl:message><xsl:copy-of select="."/></xsl:message>-->
       <xsl:apply-templates select="dcat:theme"/>
       <xsl:apply-templates select="dcat:keyword"/>
-      <xsl:apply-templates select="dct:type"/>
+
+      <xsl:call-template name="add-resource-type"/>
 
       <xsl:apply-templates select="dct:creator"/>
       <xsl:apply-templates select="dct:publisher"/>


### PR DESCRIPTION
I had to change the layout-custom-field-keywords.xsl because it was always matching thesaurus config based on the @name first then, in the template, would try to find the config related to the parent.  
The problem being that now dcat:Dataset and dcat:DataService dct:type must not be matched anymore as there is no config for them.